### PR TITLE
Change comments on timeframe for membership

### DIFF
--- a/pifu-ims/PIFU-IMS_SAS_eksempel_fravar_1.xml
+++ b/pifu-ims/PIFU-IMS_SAS_eksempel_fravar_1.xml
@@ -271,13 +271,14 @@
                 <datetime>2006-08-20</datetime>
                 <!-- tidspunkt for etablering av medlemskap, ISO8601 -->
 
-                <!-- Tidsperiode for gyldighet -->
+                <!-- Definisjon av tidsperiode (skoleår) fraværet gjelder for --> 
                 <timeframe>
-                    <begin>2012-08-16</begin>
                     <!-- fra-dato -->
-                    <end>2013-06-30</end>
+                    <begin>2012-08-16</begin>
                     <!-- til-dato -->
+                    <end>2013-06-30</end>
                 </timeframe>
+                
 
                 <!-- Utvidelser for å få med fravær -->
                 <extension>
@@ -378,12 +379,12 @@
                 <datetime>2012-08-16</datetime>
                 <!-- tidspunkt for etablering av medlemskap, ISO8601 -->
 
-                <!-- Tidsperiode for gyldighet -->
+                <!-- Definisjon av tidsperiode (skoleår) fraværet gjelder for --> 
                 <timeframe>
-                    <begin>2012-08-16</begin>
                     <!-- fra-dato -->
-                    <end>2013-06-30</end>
+                    <begin>2012-08-16</begin>
                     <!-- til-dato -->
+                    <end>2013-06-30</end>
                 </timeframe>
                 
                 <extension>

--- a/pifu-ims/PIFU-IMS_SAS_eksempel_fravar_2.xml
+++ b/pifu-ims/PIFU-IMS_SAS_eksempel_fravar_2.xml
@@ -83,13 +83,14 @@
                 <datetime>2006-08-20</datetime>
                 <!-- tidspunkt for etablering av medlemskap, ISO8601 -->
 
-                <!-- Tidsperiode for gyldighet -->
+                <!-- Definisjon av tidsperiode (skoleår) fraværet gjelder for --> 
                 <timeframe>
-                    <begin>2012-08-16</begin>
                     <!-- fra-dato -->
-                    <end>2013-06-30</end>
+                    <begin>2012-08-16</begin>
                     <!-- til-dato -->
+                    <end>2013-06-30</end>
                 </timeframe>
+                
 
                 <!-- Utvidelser for å få med fravær -->
                 <extension>
@@ -213,12 +214,12 @@
                 <datetime>2006-08-20</datetime>
                 <!-- tidspunkt for etablering av medlemskap, ISO8601 -->
 
-                <!-- Tidsperiode for gyldighet -->
+                <!-- Definisjon av tidsperiode (skoleår) fraværet gjelder for --> 
                 <timeframe>
-                    <begin>2012-08-16</begin>
                     <!-- fra-dato -->
-                    <end>2013-06-30</end>
+                    <begin>2012-08-16</begin>
                     <!-- til-dato -->
+                    <end>2013-06-30</end>
                 </timeframe>
 
                 <extension>                    

--- a/pifu-ims/PIFU-IMS_SAS_eksempel_karakter_1.xml
+++ b/pifu-ims/PIFU-IMS_SAS_eksempel_karakter_1.xml
@@ -271,12 +271,12 @@
                 <datetime>2012-08-16</datetime>
                 <!-- tidspunkt for etablering av medlemskap, ISO8601 -->
 
-                <!-- Tidsperiode for gyldighet -->
+                <!-- Definisjon av tidsperiode (skoleår) karakterene gjelder for --> 
                 <timeframe>
-                    <begin>2012-08-16</begin>
                     <!-- fra-dato -->
-                    <end>2013-06-30</end>
+                    <begin>2012-08-16</begin>
                     <!-- til-dato -->
+                    <end>2013-06-30</end>
                 </timeframe>
 
                 <!-- Karakter som ikke blir stående og ikke blir med eleven videre -->

--- a/pifu-ims/PIFU-IMS_SAS_eksempel_karakter_2.xml
+++ b/pifu-ims/PIFU-IMS_SAS_eksempel_karakter_2.xml
@@ -83,14 +83,14 @@
                 <datetime>2006-08-20</datetime>
                 <!-- tidspunkt for etablering av medlemskap, ISO8601 -->
 
-                <!-- Tidsperiode for gyldighet -->
+                <!-- Definisjon av tidsperiode (skoleår) karakterene gjelder for --> 
                 <timeframe>
-                    <begin>2012-08-16</begin>
                     <!-- fra-dato -->
-                    <end>2013-06-30</end>
+                    <begin>2012-08-16</begin>
                     <!-- til-dato -->
+                    <end>2013-06-30</end>
                 </timeframe>
-
+                
                 <!-- Karakter som ikke blir stående og ikke blir med eleven videre -->
                 <interimresult resulttype="Term 1">
                     <!-- Resultatskalaen her er Grade, diskrete karakterer -->


### PR DESCRIPTION
Changed the comment for <timeframe> element in <role>, saying it should
define schoolyear it is valid for: <!-- Definisjon av tidsperiode
(skoleår) fraværet gjelder for -->
